### PR TITLE
Release Substrate v0.1.0

### DIFF
--- a/0.13/lists/curations-0.13.json
+++ b/0.13/lists/curations-0.13.json
@@ -86,6 +86,18 @@
                         "video calls",
                         "screen sharing"
                     ]
+                },
+                {
+                    "toolListUrl": "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
+                    "toolId": "substrate",
+                    "versionBranch": "main",
+                    "tags": [
+                        "substrate",
+                        "canvas",
+                        "grid",
+                        "embedding",
+                        "assemblage"
+                    ]
                 }
             ]
         }

--- a/0.13/lists/tool-list-0.13.json
+++ b/0.13/lists/tool-list-0.13.json
@@ -213,6 +213,34 @@
                     "releasedAt": 1736866346798
                 }
             ]
+        },
+        {
+            "id": "substrate",
+            "versionBranch": "main",
+            "title": "Substrate",
+            "subtitle": "Embed Weave assets on a canvas",
+            "description": "Embed Weave assets on a canvas",
+            "icon": "https://raw.githubusercontent.com/zequez/substrate/refs/heads/main/icon.png",
+            "tags": [
+                "substrate",
+                "canvas",
+                "grid",
+                "embedding",
+                "assemblage"
+            ],
+            "versions": [
+                {
+                    "version": "0.1.1",
+                    "url": "https://github.com/zequez/substrate/releases/download/v0.1.1/substrate.webhapp",
+                    "hashes": {
+                        "happSha256": "6b6d4c60d4ddc5b82731263519a22597bbfea6d0e4eb57bfd43b16b1e7600f2c",
+                        "webhappSha256": "006165cb5864028d10cd1207a5b7217d38d16c2100baee01d3acc9e48bee5b91",
+                        "uiSha256": "ed1cf682ed5464cc247e1f7b8c8890eac0dceb62378b40b158beb2425f7661e7"
+                    },
+                    "changelog": "- Fixed a bug that caused syncing between peers not to work\n     - You can now add frames to pocket and embed instances of Substrate that are centered around that Frame\n     - You can now remove linked assets from frames\n     - Added provision to prevent inifinite recursion from happening when embedding Substrate within Substrate\n     - Refactored store so it can be initialized outside the UI components structure\n     - Made the canvas (0,0) position be at the center of the screen\n     - Made shadows all share the same z-index so they don't overlap\n     - Added provision to disable pointer events on iframes while dragging so the panning doesn't get stuck",
+                    "releasedAt": 1738676622953
+                }
+            ]
         }
     ]
 }

--- a/0.13/modify/curations-0.13.ts
+++ b/0.13/modify/curations-0.13.ts
@@ -16,60 +16,58 @@ export default defineCurationLists({
       tags: [],
       tools: [
         {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
+          toolListUrl: "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
           toolId: "vines",
           versionBranch: "1.10.x",
           tags: [""],
         },
         {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
+          toolListUrl: "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
           toolId: "zipzap",
           versionBranch: "0.3.x",
           tags: [""],
         },
         {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
+          toolListUrl: "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
           toolId: "notebooks",
           versionBranch: "0.4.x",
           tags: [""],
         },
         {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
+          toolListUrl: "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
           toolId: "talking-stickies",
           versionBranch: "0.12.x",
           tags: [""],
         },
         {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
+          toolListUrl: "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
           toolId: "kando",
           versionBranch: "0.12.x",
           tags: [""],
         },
         {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
+          toolListUrl: "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
           toolId: "gamez",
           versionBranch: "main",
           tags: ["game", "board game", "canvas", "collaboration", "play"],
         },
         {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
+          toolListUrl: "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
           toolId: "sweet",
           versionBranch: "feature/OT-0.4",
           tags: ["collaboration", "spreadsheet", "table", "data", "document", "office"],
         },
         {
-          toolListUrl:
-            "https://raw.githubusercontent.com/matthme/weave-tool-curation/refs/heads/main/0.13/lists/tool-list-0.13.json",
+          toolListUrl: "https://raw.githubusercontent.com/matthme/weave-tool-curation/refs/heads/main/0.13/lists/tool-list-0.13.json",
           toolId: "matthme.presence",
           versionBranch: "0.10.x",
           tags: ["video calls", "screen sharing"],
+        },
+        {
+          toolListUrl: "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
+          toolId: "substrate",
+          versionBranch: "main",
+          tags: ["substrate", "canvas", "grid", "embedding", "assemblage"],
         },
       ],
     },

--- a/0.13/modify/tool-list-0.13.ts
+++ b/0.13/modify/tool-list-0.13.ts
@@ -24,9 +24,9 @@ export default defineDevCollectiveToolList({
           version: "1.10.0",
           url: "https://github.com/lightningrodlabs/vines/releases/download/we-applet-rc/vines-we_applet-1.10.0.webhapp",
           hashes: {
-            "happSha256": "10d5ad294dac0fd5a2de35bd8abb4db3bc15ded7aca27a2c8d091dcf5c51cebf",
-            "webhappSha256": "75f83cf6b56106d106a1095dd9aa0bcbbb45754a887bd8d717d5c8aef7c63a92",
-            "uiSha256": "c25eef5dbe55b2d3187e9a59ed3136b0ecdfe330d11a0232a6d00b3189bcf626"
+            happSha256: "10d5ad294dac0fd5a2de35bd8abb4db3bc15ded7aca27a2c8d091dcf5c51cebf",
+            webhappSha256: "75f83cf6b56106d106a1095dd9aa0bcbbb45754a887bd8d717d5c8aef7c63a92",
+            uiSha256: "c25eef5dbe55b2d3187e9a59ed3136b0ecdfe330d11a0232a6d00b3189bcf626",
           },
           changelog: "Updates for Holochain 0.4 and Moss 0.13",
           releasedAt: 1736973182000,
@@ -46,9 +46,9 @@ export default defineDevCollectiveToolList({
           version: "0.3.0-rc.0",
           url: "https://github.com/lightningrodlabs/zipzap/releases/download/v0.3.0-rc.0/zipzap.webhapp",
           hashes: {
-            "happSha256": "57ce77725d91790298c93d4321003e2f52415ddc81a5a8b618c5874b9fd4d49b",
-            "webhappSha256": "ec95e49f74c309a824adc578b3a6c0fe04cfa70903e95cbf676267950ad3fd1d",
-            "uiSha256": "9ac1b82eb457f26cfd3a9bf6114507162154f4f7e0188112c6aac5fa666053a3"
+            happSha256: "57ce77725d91790298c93d4321003e2f52415ddc81a5a8b618c5874b9fd4d49b",
+            webhappSha256: "ec95e49f74c309a824adc578b3a6c0fe04cfa70903e95cbf676267950ad3fd1d",
+            uiSha256: "9ac1b82eb457f26cfd3a9bf6114507162154f4f7e0188112c6aac5fa666053a3",
           },
           changelog: "Updates for Holochain 0.4 and Moss 0.13",
           releasedAt: 1736192464850,
@@ -68,9 +68,9 @@ export default defineDevCollectiveToolList({
           version: "0.4.1-rc.0",
           url: "https://github.com/lightningrodlabs/notebooks/releases/download/v0.4.1-rc.0/notebooks.webhapp",
           hashes: {
-            "happSha256": "79569a97b7c4c8736576668ec428f2f18caad8b8f39c72af6df503ea0bef6193",
-            "webhappSha256": "2780343e0edb8714247361728acd6c5c03bd9e5bd56be43d45b5910b861ff2b3",
-            "uiSha256": "d778270c26884728ef4977c1052f91150fa3f024436041b648e7de9e52523b47"
+            happSha256: "79569a97b7c4c8736576668ec428f2f18caad8b8f39c72af6df503ea0bef6193",
+            webhappSha256: "2780343e0edb8714247361728acd6c5c03bd9e5bd56be43d45b5910b861ff2b3",
+            uiSha256: "d778270c26884728ef4977c1052f91150fa3f024436041b648e7de9e52523b47",
           },
           changelog: "Updates for Holochain 0.4 and Moss 0.13",
           releasedAt: 1736192464850,
@@ -90,14 +90,14 @@ export default defineDevCollectiveToolList({
           version: "0.12.0-rc.0",
           url: "https://github.com/holochain-apps/talking-stickies/releases/download/v0.12.0-rc.0/talking-stickies.webhapp",
           hashes: {
-            "happSha256": "6e5543dfe9e38f8818d95ca4fb808f435b4dad81ed7051a89e42734f3ab72d45",
-            "webhappSha256": "b5adf22ea0d586f5e9a329cd5042b5516d2163b57164d2f4201586b28b4f8b97",
-            "uiSha256": "2e52715326dc3026d3cc3772737dbd2154b22d27c69a23bc82eb26a27c1812c8"
+            happSha256: "6e5543dfe9e38f8818d95ca4fb808f435b4dad81ed7051a89e42734f3ab72d45",
+            webhappSha256: "b5adf22ea0d586f5e9a329cd5042b5516d2163b57164d2f4201586b28b4f8b97",
+            uiSha256: "2e52715326dc3026d3cc3772737dbd2154b22d27c69a23bc82eb26a27c1812c8",
           },
           changelog: "Updates for Holochain 0.4 and Moss 0.13",
           releasedAt: 1736287085974,
         },
-      ]
+      ],
     },
     {
       id: "kando",
@@ -112,9 +112,9 @@ export default defineDevCollectiveToolList({
           version: "0.12.0-rc.0",
           url: "https://github.com/holochain-apps/kando/releases/download/v0.12.0-rc.0/kando.webhapp",
           hashes: {
-            "happSha256": "fd3a1781fb480d87117af276e5da0d3daa6e99f14e333480ca90f075eeb6455c",
-            "webhappSha256": "e5cfe34756043e01da9285158263300e6cf8b9d1659655c46badb45c169270fd",
-            "uiSha256": "f120a1982084e908f379a5e8e991f493848c352c06a27ce7e8eb25ef06079d95"
+            happSha256: "fd3a1781fb480d87117af276e5da0d3daa6e99f14e333480ca90f075eeb6455c",
+            webhappSha256: "e5cfe34756043e01da9285158263300e6cf8b9d1659655c46badb45c169270fd",
+            uiSha256: "f120a1982084e908f379a5e8e991f493848c352c06a27ce7e8eb25ef06079d95",
           },
           changelog: "Updates for Holochain 0.4 and Moss 0.13",
           releasedAt: 1736019237925,
@@ -123,9 +123,9 @@ export default defineDevCollectiveToolList({
           version: "0.12.0-rc.1",
           url: "https://github.com/holochain-apps/kando/releases/download/v0.12.0-rc.1/kando.webhapp",
           hashes: {
-            "happSha256": "fd3a1781fb480d87117af276e5da0d3daa6e99f14e333480ca90f075eeb6455c",
-            "webhappSha256": "eae1f8efc5de5c225e811123bec6a8a0c479b5089cf35682403078a225a5b85b",
-            "uiSha256": "4ad0fd8050b7e294e6d5825636585f6875eecdb84730a729f79348e692191337"
+            happSha256: "fd3a1781fb480d87117af276e5da0d3daa6e99f14e333480ca90f075eeb6455c",
+            webhappSha256: "eae1f8efc5de5c225e811123bec6a8a0c479b5089cf35682403078a225a5b85b",
+            uiSha256: "4ad0fd8050b7e294e6d5825636585f6875eecdb84730a729f79348e692191337",
           },
           changelog: "Asset fixes.",
           releasedAt: 1736110661818,
@@ -144,12 +144,9 @@ export default defineDevCollectiveToolList({
         {
           version: "0.7.8",
           hashes: {
-            happSha256:
-              "6335eca61415e769c22934d354614e581e65eb4728be0eff2f447c3d729c1f6d",
-            webhappSha256:
-              "dfc240caf9721b05138f120d2ffeb9d146f51a2a974c4feb734927200c535b84",
-            uiSha256:
-              "1db2d9804278973c72c63be4887d571ce8b414b0778cb69e94694ddb989ad1e2",
+            happSha256: "6335eca61415e769c22934d354614e581e65eb4728be0eff2f447c3d729c1f6d",
+            webhappSha256: "dfc240caf9721b05138f120d2ffeb9d146f51a2a974c4feb734927200c535b84",
+            uiSha256: "1db2d9804278973c72c63be4887d571ce8b414b0778cb69e94694ddb989ad1e2",
           },
           url: "https://github.com/holochain-apps/gamez/releases/download/v0.7.8/gamez.webhapp",
           changelog: `
@@ -167,12 +164,9 @@ export default defineDevCollectiveToolList({
         {
           version: "0.7.7",
           hashes: {
-            happSha256:
-              "6335eca61415e769c22934d354614e581e65eb4728be0eff2f447c3d729c1f6d",
-            webhappSha256:
-              "d75b28807052bbf56d0641a51c63fde6d5f6f80a8efe4c782581473c8de4d4bf",
-            uiSha256:
-              "f8fb3e75e7670c41cad9c71700b78d25bc8e996276e878d94d40d8a4cb1892e3",
+            happSha256: "6335eca61415e769c22934d354614e581e65eb4728be0eff2f447c3d729c1f6d",
+            webhappSha256: "d75b28807052bbf56d0641a51c63fde6d5f6f80a8efe4c782581473c8de4d4bf",
+            uiSha256: "f8fb3e75e7670c41cad9c71700b78d25bc8e996276e878d94d40d8a4cb1892e3",
           },
           url: "https://github.com/holochain-apps/gamez/releases/download/v0.7.7/gamez.webhapp",
           changelog: `- Fixed WALs not loading when you first open a space
@@ -200,12 +194,41 @@ export default defineDevCollectiveToolList({
           version: "0.10.4",
           url: "https://github.com/lightningrodlabs/sweet/releases/download/0.10.4/calcy.webhapp",
           hashes: {
-            "happSha256": "16113b9ece15e1cf794e5f24409162a24dcdb3c18e10af6a64c2d16e56b339e9",
-            "webhappSha256": "496b0567cabe44694af6f648ea99fcc90319722909a1e5555d46668c4aed7984",
-            "uiSha256": "30db0bb19775630f8acf6c7584c84e9de307a79c9a721dedd73e7566065e6812"
-        },
+            happSha256: "16113b9ece15e1cf794e5f24409162a24dcdb3c18e10af6a64c2d16e56b339e9",
+            webhappSha256: "496b0567cabe44694af6f648ea99fcc90319722909a1e5555d46668c4aed7984",
+            uiSha256: "30db0bb19775630f8acf6c7584c84e9de307a79c9a721dedd73e7566065e6812",
+          },
           changelog: "",
           releasedAt: 1736866346798,
+        },
+      ],
+    },
+    {
+      id: "substrate",
+      versionBranch: "main",
+      title: "Substrate",
+      subtitle: "Embed Weave assets on a canvas",
+      description: "Embed Weave assets on a canvas",
+      icon: "https://raw.githubusercontent.com/zequez/substrate/refs/heads/main/icon.png",
+      tags: ["substrate", "canvas", "grid", "embedding", "assemblage"],
+      versions: [
+        {
+          version: "0.1.1",
+          url: "https://github.com/zequez/substrate/releases/download/v0.1.1/substrate.webhapp",
+          hashes: {
+            happSha256: "6b6d4c60d4ddc5b82731263519a22597bbfea6d0e4eb57bfd43b16b1e7600f2c",
+            webhappSha256: "006165cb5864028d10cd1207a5b7217d38d16c2100baee01d3acc9e48bee5b91",
+            uiSha256: "ed1cf682ed5464cc247e1f7b8c8890eac0dceb62378b40b158beb2425f7661e7",
+          },
+          changelog: `- Fixed a bug that caused syncing between peers not to work
+     - You can now add frames to pocket and embed instances of Substrate that are centered around that Frame
+     - You can now remove linked assets from frames
+     - Added provision to prevent inifinite recursion from happening when embedding Substrate within Substrate
+     - Refactored store so it can be initialized outside the UI components structure
+     - Made the canvas (0,0) position be at the center of the screen
+     - Made shadows all share the same z-index so they don't overlap
+     - Added provision to disable pointer events on iframes while dragging so the panning doesn't get stuck`,
+          releasedAt: 1738676622953,
         },
       ],
     },


### PR DESCRIPTION
# 0.1.0
  - There is an infinite grid-based canvas you can pan and zoom
  - You can drag squares to create frames that can have embedded Weave assets
  - You can resize, move and delete the frames
  - Frames are synced automatically to every group member
  - Uses Generic DNA as Holochain backend
  - Uses Svelte 5 for UI
  - Uses Weave Dev Context for development environment
# 0.1.1
  - Fixed a bug that caused syncing between peers not to work
  - You can now add frames to pocket and embed instances of Substrate that are centered around that Frame
  - You can now remove linked assets from frames
  - Added provision to prevent inifinite recursion from happening when embedding Substrate within Substrate
  - Refactored store so it can be initialized outside the UI components structure
  - Made the canvas (0,0) position be at the center of the screen
  - Made shadows all share the same z-index so they don't overlap
  - Added provision to disable pointer events on iframes while dragging so the panning doesn't get stuck