### PR TITLE
Release Substrate v0.1.4

### DIFF
--- a/0.13/lists/tool-list-0.13.json
+++ b/0.13/lists/tool-list-0.13.json
@@ -239,6 +239,17 @@
                     },
                     "changelog": "- Fixed a bug that caused syncing between peers not to work\n     - You can now add frames to pocket and embed instances of Substrate that are centered around that Frame\n     - You can now remove linked assets from frames\n     - Added provision to prevent inifinite recursion from happening when embedding Substrate within Substrate\n     - Refactored store so it can be initialized outside the UI components structure\n     - Made the canvas (0,0) position be at the center of the screen\n     - Made shadows all share the same z-index so they don't overlap\n     - Added provision to disable pointer events on iframes while dragging so the panning doesn't get stuck",
                     "releasedAt": 1738676622953
+                },
+                {
+                    "version": "0.1.4",
+                    "url": "https://github.com/zequez/substrate/releases/download/v0.1.4/substrate.webhapp",
+                    "hashes": {
+                        "happSha256": "6b6d4c60d4ddc5b82731263519a22597bbfea6d0e4eb57bfd43b16b1e7600f2c",
+                        "webhappSha256": "a5803bab452a2b72f22f8a331ce03b0d246c08910c945a99eb49b9c4d3d049f7",
+                        "uiSha256": "ba0523ff9b3756fd1ef9fd89e965355640f7d6cd5b5f5cda8d56e6a7693e2253"
+                    },
+                    "changelog": "- Added WASD keyboard-based movement\n  - You can now select frames and move them or trash them all together\n  - Some code clean up and organization\n  - Improved agents display; show avatars\n  - Added tooltips",
+                    "releasedAt": 1739200275760
                 }
             ]
         }

--- a/0.13/modify/tool-list-0.13.ts
+++ b/0.13/modify/tool-list-0.13.ts
@@ -26,7 +26,7 @@ export default defineDevCollectiveToolList({
           hashes: {
             happSha256: "1fddfda589f79279e5953c98abc8c515ed790073a1c28065da58d84a1398d809",
             webhappSha256: "f2a86ba74d30cbfb62bc3e86dd921d69e2d1a2461b85b29c93dbc4a6b1dcea94",
-            uiSha256: "ef2ee91c5bd985752487f88bd97fe4ed67adcecbb0856d663b406f145cb42749"
+            uiSha256: "ef2ee91c5bd985752487f88bd97fe4ed67adcecbb0856d663b406f145cb42749",
           },
           changelog: "Fixed DMs & notifications received via signals",
           releasedAt: 1738617365000,
@@ -229,6 +229,21 @@ export default defineDevCollectiveToolList({
      - Made shadows all share the same z-index so they don't overlap
      - Added provision to disable pointer events on iframes while dragging so the panning doesn't get stuck`,
           releasedAt: 1738676622953,
+        },
+        {
+          version: "0.1.4",
+          url: "https://github.com/zequez/substrate/releases/download/v0.1.4/substrate.webhapp",
+          hashes: {
+            happSha256: "6b6d4c60d4ddc5b82731263519a22597bbfea6d0e4eb57bfd43b16b1e7600f2c",
+            webhappSha256: "a5803bab452a2b72f22f8a331ce03b0d246c08910c945a99eb49b9c4d3d049f7",
+            uiSha256: "ba0523ff9b3756fd1ef9fd89e965355640f7d6cd5b5f5cda8d56e6a7693e2253",
+          },
+          changelog: `- Added WASD keyboard-based movement
+  - You can now select frames and move them or trash them all together
+  - Some code clean up and organization
+  - Improved agents display; show avatars
+  - Added tooltips`,
+          releasedAt: 1739200275760,
         },
       ],
     },


### PR DESCRIPTION
# 0.1.4
  - Added WASD keyboard-based movement
  - You can now select frames and move them or trash them all together
  - Some code clean up and organization
  - Improved agents display; show avatars
  - Added tooltips
# 0.1.3
  - Instant syncing with Generic DNA
  - You can now paint the canvas grid blocks with colors
  - When running in fullscreen you can pan the canvas by moving the mouse to the edge of the screen (not functional instide Weave yet until fullscreen permissions are enabled for applets)
# 0.1.2
  - Extracted most canvas UI-related states out of the main store
  - Added max zoom out button that zooms out and pans so that all frames are visible simuntaneously
  - Adjust max zoom out so that all frames can be visible simultaneosly on the maximum zoom out
  - Added optimization so only frames in the viewport are rendered
  - Added optimization so assets are not loaded when far out of the zoom level
  - Make it so frames cannot be overlapped
  - The resize handles are now zoom-level adapted and disabled during very far zoom out
  - At <=0.5 zoom frames turn into move-only mode and you can just drag them from anywhere
  - Fixed grid not rendering on first app start
  - Added new frame controls that are hidden and show at the edge of the frame when hovering (only at >0.5 zoom)