### PR TITLE
Deprecate old vines

### DIFF
--- a/0.13/lists/curations-0.13.json
+++ b/0.13/lists/curations-0.13.json
@@ -31,26 +31,10 @@
                 },
                 {
                     "toolListUrl": "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
-                    "toolId": "vines",
-                    "versionBranch": "1.13.x",
-                    "tags": [
-                        "chat"
-                    ]
-                },
-                {
-                    "toolListUrl": "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
                     "toolId": "acorn",
                     "versionBranch": "11.x.x",
                     "tags": [
                         "project-management"
-                    ]
-                },
-                {
-                    "toolListUrl": "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
-                    "toolId": "vines",
-                    "versionBranch": "1.11.x",
-                    "tags": [
-                        "chat"
                     ]
                 },
                 {

--- a/0.13/lists/tool-list-0.13.json
+++ b/0.13/lists/tool-list-0.13.json
@@ -79,7 +79,8 @@
                     "changelog": "Changed Add button UI. Many small bug fixes & polish.",
                     "releasedAt": 1739562342000
                 }
-            ]
+            ],
+            "deprecation": "Newer version available."
         },
         {
             "id": "vines",
@@ -103,7 +104,8 @@
                     "changelog": "Fixed and added cross-group-view & view message edit history",
                     "releasedAt": 1739562332000
                 }
-            ]
+            ],
+            "deprecation": "Newer version available."
         },
         {
             "id": "vines",
@@ -127,7 +129,8 @@
                     "changelog": "Fixed DMs & notifications received via signals",
                     "releasedAt": 1738617365000
                 }
-            ]
+            ],
+            "deprecation": "Newer version available."
         },
         {
             "id": "zipzap",

--- a/0.13/modify/curations-0.13.ts
+++ b/0.13/modify/curations-0.13.ts
@@ -32,23 +32,9 @@ export default defineCurationLists({
         {
           toolListUrl:
             "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
-          toolId: "vines",
-          versionBranch: "1.13.x",
-          tags: ["chat"],
-        },
-        {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
           toolId: "acorn",
           versionBranch: "11.x.x",
           tags: ["project-management"],
-        },
-        {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.13/tool-list-0.13.json",
-          toolId: "vines",
-          versionBranch: "1.11.x",
-          tags: ["chat"],
         },
         {
           toolListUrl:

--- a/0.13/modify/tool-list-0.13.ts
+++ b/0.13/modify/tool-list-0.13.ts
@@ -87,6 +87,7 @@ export default defineDevCollectiveToolList({
           releasedAt: 1739562342000,
         },
       ],
+      deprecation: "Newer version available.",
     },
     {
       id: "vines",
@@ -113,6 +114,7 @@ export default defineDevCollectiveToolList({
           releasedAt: 1739562332000,
         },
       ],
+      deprecation: "Newer version available.",
     },
     {
       id: "vines",
@@ -138,6 +140,7 @@ export default defineDevCollectiveToolList({
           releasedAt: 1738617365000,
         },
       ],
+      deprecation: "Newer version available.",
     },
     {
       id: "zipzap",


### PR DESCRIPTION
Deprecates the old Vines versions and removes them from the curation list (but not from the tool list, otherwise people can't join already existing Vines instances in groups for that version)