### PR TITLE
Add 0.16 curation folder for Moss 0.7 branch

### DIFF
--- a/0.16/README.md
+++ b/0.16/README.md
@@ -1,0 +1,47 @@
+# Curation List for Moss 0.16
+
+This folder contains a curations list and a Tools list.
+
+**Curation List**:
+A curation list is a list of curations of Weave Tools maintained by a curator. It can contain
+multiple curations listing Tools of different developer collectives.
+
+**Tools List**:
+A Tools list is a list of Weave Tools maintained by a developer collective. It contains information
+about the developer collective as well as a list of Tools and available versions thereof. A Tool
+is identified by an `id` and a `versionBranch`, where all versions of a Tool belonging to the same
+`versionBranch` are assumed to be compatible.
+
+## Computing Sha256 Hashes of .webhapp files
+
+To verify the integrity of the files, the sha256 hashes of the `.webhapp`, `.happ` and the UI are
+required for every Tool version in a Tools list. These get stored in the group DNA of a Moss
+group so that each group member can verify that they download the same Tool as other group
+members.
+
+To compute these hashes you can use the Weave CLI [`@theweave/cli`](https://www.npmjs.com/package/@theweave/cli) and
+run the following command:
+```
+weave hash-webhapp [version] [path or URL to your Tool's webhapp file]
+```
+
+> [!IMPORTANT]
+> It is important to use the Weave CLI for computing the hashes as the hashes may differ from computing them manually
+and they need to match with how Moss computes them.
+
+## Modifying the Curation List
+
+0. Run `npm install`
+1. Go to `./modify/curations-0.16.ts` and change the file as needed
+2. Run `npm run write-lists` which should update `./lists/curations-0.16.json`.
+3. run `npm run test` to run basic validity checks for the generated json file.
+4. Make a PR with the new change
+
+## Modifying the Tools List
+
+0. Run `npm install`
+1. Go to `./modify/tool-list-0.16.ts` and change the file as needed
+2. Run `npm run write-lists` which should update `./lists/tool-list-0.16.json`.
+3. run `npm run test` to run basic validity checks for the generated json file.
+4. Make a PR with the new change
+

--- a/0.16/lists/curations-0.16.json
+++ b/0.16/lists/curations-0.16.json
@@ -1,0 +1,28 @@
+{
+    "curator": {
+        "name": "Lightningrod Labs",
+        "description": "The official curation of Tools from Lightningrod Labs",
+        "contact": {
+            "website": "https://lightningrodlabs.org"
+        },
+        "icon": "https://lightningrodlabs.org/lrl_logo.png"
+    },
+    "curationLists": {
+        "default": {
+            "name": "Default Curation List",
+            "description": "Default Curation List of Lightningrod Labs",
+            "tags": [],
+            "tools": [
+                {
+                    "toolListUrl": "https://lightningrodlabs.org/weave-tool-curation/0.16/tool-list-0.16.json",
+                    "toolId": "ziptest",
+                    "versionBranch": "0.5.x",
+                    "tags": [
+                        "testing"
+                    ],
+                    "visiblity": "low"
+                }
+            ]
+        }
+    }
+}

--- a/0.16/lists/tool-list-0.16.json
+++ b/0.16/lists/tool-list-0.16.json
@@ -1,0 +1,37 @@
+{
+    "developerCollective": {
+        "id": "lightningrodlabs",
+        "name": "Lightningrod Labs",
+        "description": "Nurturing The Holochain Ecosystem",
+        "icon": "https://lightningrodlabs.org/lrl_logo.png",
+        "contact": {
+            "website": "https://lightningrodlabs.org"
+        }
+    },
+    "tools": [
+        {
+            "id": "ziptest",
+            "versionBranch": "0.5.x",
+            "title": "ZipTest",
+            "subtitle": "Simple performance testing",
+            "description": "Send batches of signals and watch acks com back.  Create entries and watch how long it takes for them to propagate.",
+            "icon": "https://github.com/holochain/ziptest/releases/download/ziptest-v0.3.0/ziptest_icon.png",
+            "tags": [
+                "testing"
+            ],
+            "versions": [
+                {
+                    "version": "0.5.0-dev.0",
+                    "hashes": {
+                        "happSha256": "06d6957ff2812e16f3707315f6ea397260cc2bec690eaba9522b6f30755e8085",
+                        "webhappSha256": "f49b368096c2ac4f40a78e1ce56d5cf507331efbe6779d927b17ac44650ee079",
+                        "uiSha256": "8ed9f60e5eaa484bc350a133cfe4045ccb65b87593c742d44218c1244b1fe0c8"
+                    },
+                    "url": "https://github.com/holochain/ziptest/releases/download/v0.5.0-dev.0/ziptest.webhapp",
+                    "changelog": "Update to holochain 0.7 line",
+                    "releasedAt": 1779219790524
+                }
+            ]
+        }
+    ]
+}

--- a/0.16/modify/curations-0.16.ts
+++ b/0.16/modify/curations-0.16.ts
@@ -1,0 +1,29 @@
+import { defineCurationLists } from "@theweave/moss-types";
+
+export default defineCurationLists({
+  curator: {
+    name: "Lightningrod Labs",
+    description: "The official curation of Tools from Lightningrod Labs",
+    contact: {
+      website: "https://lightningrodlabs.org",
+    },
+    icon: "https://lightningrodlabs.org/lrl_logo.png",
+  },
+  curationLists: {
+    default: {
+      name: "Default Curation List",
+      description: "Default Curation List of Lightningrod Labs",
+      tags: [],
+      tools: [
+        {
+          toolListUrl:
+            "https://lightningrodlabs.org/weave-tool-curation/0.16/tool-list-0.16.json",
+          toolId: "ziptest",
+          versionBranch: "0.5.x",
+          tags: ["testing"],
+          visiblity: "low",
+        },
+      ],
+    },
+  },
+});

--- a/0.16/modify/tool-list-0.16.ts
+++ b/0.16/modify/tool-list-0.16.ts
@@ -1,0 +1,41 @@
+import { defineDevCollectiveToolList } from "@theweave/moss-types";
+
+export default defineDevCollectiveToolList({
+  developerCollective: {
+    id: "lightningrodlabs",
+    name: "Lightningrod Labs",
+    description: "Nurturing The Holochain Ecosystem",
+    icon: "https://lightningrodlabs.org/lrl_logo.png",
+    contact: {
+      website: "https://lightningrodlabs.org",
+    },
+  },
+  tools: [
+    {
+      id: "ziptest",
+      versionBranch: "0.5.x",
+      title: "ZipTest",
+      subtitle: "Simple performance testing",
+      description:
+        "Send batches of signals and watch acks com back.  Create entries and watch how long it takes for them to propagate.",
+      icon: "https://github.com/holochain/ziptest/releases/download/ziptest-v0.3.0/ziptest_icon.png",
+      tags: ["testing"],
+      versions: [
+        {
+          version: "0.5.0-dev.0",
+          hashes: {
+            happSha256:
+              "06d6957ff2812e16f3707315f6ea397260cc2bec690eaba9522b6f30755e8085",
+            webhappSha256:
+              "f49b368096c2ac4f40a78e1ce56d5cf507331efbe6779d927b17ac44650ee079",
+            uiSha256:
+              "8ed9f60e5eaa484bc350a133cfe4045ccb65b87593c742d44218c1244b1fe0c8",
+          },
+          url: "https://github.com/holochain/ziptest/releases/download/v0.5.0-dev.0/ziptest.webhapp",
+          changelog: "Update to holochain 0.7 line",
+          releasedAt: 1779219790524,
+        },
+      ],
+    },
+  ],
+});

--- a/0.16/package-lock.json
+++ b/0.16/package-lock.json
@@ -1,0 +1,1139 @@
+{
+  "name": "@lightningrodlabs/weave-tool-curation-0.16",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@lightningrodlabs/weave-tool-curation-0.16",
+      "version": "0.1.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@theweave/moss-types": "0.5.4",
+        "semver": "7.6.3",
+        "ts-node": "10.9.2"
+      }
+    },
+    "node_modules/@alenaksu/json-viewer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@alenaksu/json-viewer/-/json-viewer-2.1.2.tgz",
+      "integrity": "sha512-hyR5EUc0GZMTjlSULJZlMzEYB896ICbCf1+5YLQRSAczGRWy42UWac5PcXM4spuyTkrEHHlOZBTVEq34f9+JVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3.2.0"
+      }
+    },
+    "node_modules/@bitgo/blake2b": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@bitgo/blake2b/-/blake2b-3.2.4.tgz",
+      "integrity": "sha512-46PEgEVPxecNJ/xczggIllSxIkFIvvbVM0OfIDdNJ5qpFHUeBCkNIiGdzC3fYZlsv7bVTdUZOj79GcFBLMYBqA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bitgo/blake2b-wasm": "^3.2.3",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/@bitgo/blake2b-wasm": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@bitgo/blake2b-wasm/-/blake2b-wasm-3.2.3.tgz",
+      "integrity": "sha512-NaurBrMaEpjfg7EdUJgW/c6byt27O6q1ZaxB5Ita10MjjYjUu0SyYF4q7JPNxpHF/lMxb0YZakOxigbDBu9Jjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nanoassert": "^1.0.0"
+      }
+    },
+    "node_modules/@bitgo/blake2b-wasm/node_modules/nanoassert": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+      "integrity": "sha512-C40jQ3NzfkP53NsO8kEOFd79p4b9kDXQMwgiY1z8ZwrDZgUyom0AHwGegF4Dm99L+YoYhuaB0ceerUcXmqr1rQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
+      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@holo-host/identicon": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@holo-host/identicon/-/identicon-0.1.0.tgz",
+      "integrity": "sha512-Dn5pTV/m3XaK1Zvq3liw/vQUt7goM7Y84x2zUyH8cb9CNMs4kPCNHs3kalbJZ/ymzFvwcdiLwwNW8AKk+WWN5A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@holochain-open-dev/elements": {
+      "version": "0.601.1",
+      "resolved": "https://registry.npmjs.org/@holochain-open-dev/elements/-/elements-0.601.1.tgz",
+      "integrity": "sha512-DN7DNsdZIxWZfnjEHeSK5CpDHWqjfHlpB6FUWQXZ5PRKCqER5WeKmHd/F2dAhQeJvFhlTejM1sFomG8l8cU8Gg==",
+      "dev": true,
+      "dependencies": {
+        "@holo-host/identicon": "^0.1.0",
+        "@holochain/client": "=0.20.4",
+        "@lit/localize": "^0.12.2",
+        "@mdi/js": "^7.4.47",
+        "@shoelace-style/shoelace": "^2.20.1",
+        "lit": "^3.0.2",
+        "prosemirror-commands": "^1.5.2",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-view": "^1.31.3"
+      }
+    },
+    "node_modules/@holochain-open-dev/profiles": {
+      "version": "0.601.4",
+      "resolved": "https://registry.npmjs.org/@holochain-open-dev/profiles/-/profiles-0.601.4.tgz",
+      "integrity": "sha512-bwk4itVnKgArHAaDXR8WeYgS2ueHHPv/szxRcGNZDE0o4XKk0GHnZGTMEcyGgu4lrMSi5ywr1M932gRaEffi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@holochain-open-dev/elements": "^0.601.0",
+        "@holochain-open-dev/stores": "^0.601.0",
+        "@holochain-open-dev/utils": "^0.601.0",
+        "@holochain/client": "^0.20.4",
+        "@lit/context": "^1.0.1",
+        "@lit/localize": "^0.12.0",
+        "@mdi/js": "^7.1.96",
+        "@shoelace-style/shoelace": "^2.11.0",
+        "lit": "^3.0.2"
+      }
+    },
+    "node_modules/@holochain-open-dev/stores": {
+      "version": "0.601.1",
+      "resolved": "https://registry.npmjs.org/@holochain-open-dev/stores/-/stores-0.601.1.tgz",
+      "integrity": "sha512-6F23DAOYa4YF7Fw8LgOFad+UC0s1Hfhhnge0HkWaA6gxHpyx0sfz/ubF8GcP4kXmH67UfAjbPtfR+5+ssVnIsw==",
+      "dev": true,
+      "dependencies": {
+        "@alenaksu/json-viewer": "^2.1.2",
+        "@holochain-open-dev/utils": "^0.601.0",
+        "@holochain/client": "=0.20.4",
+        "@scoped-elements/cytoscape": "^0.2.7",
+        "@shoelace-style/shoelace": "^2.20.1",
+        "lit": "^3.0.2",
+        "lit-svelte-stores": "^0.3.3",
+        "svelte": "^3.53.1"
+      }
+    },
+    "node_modules/@holochain-open-dev/utils": {
+      "version": "0.601.1",
+      "resolved": "https://registry.npmjs.org/@holochain-open-dev/utils/-/utils-0.601.1.tgz",
+      "integrity": "sha512-irje5FRLm2KwlumYzjqThK0V121d7VfP3TsIOPJJHbKiPfodqku3m9u/5uf0Ou3Lmr8P5HtaVR7hS5jRCxaBTg==",
+      "dev": true,
+      "dependencies": {
+        "@holochain/client": "=0.20.4",
+        "@msgpack/msgpack": "^3.1.3",
+        "blakejs": "^1.2.1",
+        "emittery": "^1.2.0",
+        "lodash-es": "^4.17.21",
+        "sort-keys": "^5.0.0"
+      }
+    },
+    "node_modules/@holochain/client": {
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.20.4.tgz",
+      "integrity": "sha512-O/740M5LOVPaVJzkSIW+cE14t4kEXU8slK5WUEldAaMcqFY5Rzpvzun0e9N8q66FxkaluwwMU5HY5tlufKfngA==",
+      "dev": true,
+      "license": "CAL-1.0",
+      "dependencies": {
+        "@bitgo/blake2b": "^3.2.4",
+        "@msgpack/msgpack": "^3.1.2",
+        "emittery": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-base64": "^3.7.8",
+        "js-sha512": "^0.9.0",
+        "libsodium-wrappers": "^0.8.4",
+        "lodash-es": "^4.17.21",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18.0.0 || >=20.0.0 || >= 22.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/context": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.6.tgz",
+      "integrity": "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.1.0"
+      }
+    },
+    "node_modules/@lit/localize": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lit/localize/-/localize-0.12.2.tgz",
+      "integrity": "sha512-Qv9kvgJKDq/JVSwXOxuWvQnnOBysHA99ti9im9a4fImCmx+fto+XXcUYQbjZHqiueEEc4V20PcRDPO+1g/6seQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "lit": "^3.2.0"
+      }
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@mdi/js": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
+      "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-wc/scoped-elements": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-2.2.4.tgz",
+      "integrity": "sha512-12X4F4QGPWcvPbxAiJ4v8wQFCOu+laZHRGfTrkoj+3JzACCtuxHG49YbuqVzQ135QPKCuhP9wA0kpGGEfUegyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0",
+        "@open-wc/dedupe-mixin": "^1.4.0"
+      }
+    },
+    "node_modules/@scoped-elements/cytoscape": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@scoped-elements/cytoscape/-/cytoscape-0.2.7.tgz",
+      "integrity": "sha512-hvb33z021Jg01oTyWfsvOf6LK5SAqh8u8iJVCyeC4zCoro6CBfwNjbLCLgUMRtXnkVkQQkD979vAu8E+hCojJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-wc/scoped-elements": "^2.0.1",
+        "@types/cytoscape": "^3.19.0",
+        "cytoscape": "^3.20.0",
+        "cytoscape-cola": "^2.5.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-dagre": "^2.3.2",
+        "cytoscape-klay": "^3.1.4",
+        "lit": "^2.0.2",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/@scoped-elements/cytoscape/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@scoped-elements/cytoscape/node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@scoped-elements/cytoscape/node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/@scoped-elements/cytoscape/node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@shoelace-style/animations": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.2.0.tgz",
+      "integrity": "sha512-avvo1xxkLbv2dgtabdewBbqcJfV0e0zCwFqkPMnHFGbJbBHorRFfMAHh1NG9ymmXn0jW95ibUVH03E1NYXD6Gw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/claviska"
+      }
+    },
+    "node_modules/@shoelace-style/localize": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.2.2.tgz",
+      "integrity": "sha512-h3+2/cFWGaw3KQUwintkP4Cy3PtrVW//ysr9DM5nOfIXYekgrHwsELk/nyxc8hmjVP/Kcon7KCzvUtSwUBipfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shoelace-style/shoelace": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.20.1.tgz",
+      "integrity": "sha512-FSghU95jZPGbwr/mybVvk66qRZYpx5FkXL+vLNpy1Vp8UsdwSxXjIHE3fsvMbKWTKi9UFfewHTkc5e7jAqRYoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.1.0",
+        "@floating-ui/dom": "^1.6.12",
+        "@lit/react": "^1.0.6",
+        "@shoelace-style/animations": "^1.2.0",
+        "@shoelace-style/localize": "^3.2.1",
+        "composed-offset-position": "^0.0.6",
+        "lit": "^3.2.1",
+        "qr-creator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14.17.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/claviska"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.33.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.12.tgz",
+      "integrity": "sha512-d5KrXIdPolLp8VpGpZAQvEz8ioVtFlUQSyCIS2sEBi7FKhceIB7nj9BlNfqqvp5wmOfg8v8bP1rAvYYkjz21/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@theweave/api": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@theweave/api/-/api-0.6.7.tgz",
+      "integrity": "sha512-hMbEU9wAK/8DhaQIChhJy3rkmF27VNP8UnvBxXNVf2Pz/cKkVmN/vlUdUvQafMNfB7Ni8h+yC+qUxKO8JM9hfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@holochain-open-dev/profiles": "^0.601.4",
+        "@holochain/client": "=0.20.4",
+        "@msgpack/msgpack": "^2.8.0",
+        "js-base64": "^3.7.2"
+      }
+    },
+    "node_modules/@theweave/api/node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@theweave/moss-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@theweave/moss-types/-/moss-types-0.5.4.tgz",
+      "integrity": "sha512-sM9ucUQzKKHqGOTOZCf2jCMeWoct7VUr0DJWUqVoqMlWVeKkBR1AiX8x3pnFMHCmr5q9w1hU7OxkZYevrg6bLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@holochain/client": "=0.20.4",
+        "@sinclair/typebox": "0.33.12",
+        "@theweave/api": "^0.6.7"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/cytoscape": {
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.21.9.tgz",
+      "integrity": "sha512-JyrG4tllI6jvuISPjHK9j2Xv/LTbnLekLke5otGStjFluIyA9JjgnvgZrSBsp8cEDpiTjwgZUZwpPv8TSBcoLw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/composed-offset-position": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.6.tgz",
+      "integrity": "sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@floating-ui/utils": "^0.2.5"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.4",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.4.tgz",
+      "integrity": "sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cola": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-2.5.1.tgz",
+      "integrity": "sha512-4/2S9bW1LvdsEPmxXN1OEAPFPbk7DvCx2c9d+TblkQAAvptGaSgtPWCByTEGgT8UxCxcVqes2aFPO5pzwo7R2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webcola": "^3.4.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-dagre": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.5.0.tgz",
+      "integrity": "sha512-VG2Knemmshop4kh5fpLO27rYcyUaaDkRw+6PiX4bstpB+QFt0p2oauMrsjVbUamGWQ6YNavh7x2em2uZlzV44g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dagre": "^0.8.5"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.22"
+      }
+    },
+    "node_modules/cytoscape-klay": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cytoscape-klay/-/cytoscape-klay-3.1.4.tgz",
+      "integrity": "sha512-VwPj0VR25GPfy6qXVQRi/MYlZM/zkdvRhHlgqbM//lSvstgM6fhp3ik/uM8Wr8nlhskfqz/M1fIDmR6UckbS2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "klayjs": "^0.4.1"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emittery": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-1.2.1.tgz",
+      "integrity": "sha512-sFz64DCRjirhwHLxofFqxYQm6DCp6o0Ix7jwKQvuCHPn4GMRZNuBZyLPu9Ccmk/QSCAMZt6FOUqA8JZCQvA9fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-sha512": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.9.0.tgz",
+      "integrity": "sha512-mirki9WS/SUahm+1TbAPkqvbCiCfOAAsyXeHxK1UkullnJVVqoJG2pL9ObvT05CN+tM7fxhfYm0NbXn+1hWoZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/klayjs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/klayjs/-/klayjs-0.4.1.tgz",
+      "integrity": "sha512-WUNxuO7O79TEkxCj6OIaK5TJBkaWaR/IKNTakgV9PwDn+mrr63MLHed34AcE2yTaDntgO6l0zGFIzhcoTeroTA==",
+      "dev": true,
+      "license": "EPL-1.0"
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/libsodium": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.4.tgz",
+      "integrity": "sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.4.tgz",
+      "integrity": "sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.8.0"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/lit-svelte-stores": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lit-svelte-stores/-/lit-svelte-stores-0.3.3.tgz",
+      "integrity": "sha512-jtaHfgSlDuiwzmKHr6iF9uW6wV/CMRkj6QRCOnKrtRdb+uAUIiqhhNhBV2JXDO0OpCcTpqkM8kOEnotlLAYEAQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lit": "^3.0.0",
+        "lodash-es": "^4.17.21",
+        "svelte": "^3.38.3"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
+      "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/qr-creator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
+      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sort-keys": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.1.0.tgz",
+      "integrity": "sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "3.59.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
+      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webcola": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
+      "integrity": "sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3",
+        "d3-drag": "^1.0.4",
+        "d3-shape": "^1.3.5",
+        "d3-timer": "^1.0.5"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/0.16/package.json
+++ b/0.16/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@lightningrodlabs/weave-tool-curation-0.16",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --loader ts-node/esm ./validate-lists.js",
+    "write-curation-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-curation-list.js",
+    "write-collective-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-collective-list.js",
+    "write-lists": "npm run write-curation-list && npm run write-collective-list && npm run test"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "devDependencies": {
+    "@theweave/moss-types": "0.5.4",
+    "ts-node": "10.9.2",
+    "semver": "7.6.3"
+  }
+}

--- a/0.16/tsconfig.json
+++ b/0.16/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "sourceMap": false,
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": false,
+    "noImplicitReturns": true
+  }
+}

--- a/0.16/validate-lists.js
+++ b/0.16/validate-lists.js
@@ -1,0 +1,99 @@
+import fs from "fs";
+import semver from "semver";
+import curationListObject from "./modify/curations-0.16.ts";
+import toolListObject from "./modify/tool-list-0.16.ts";
+const curationListJSON = JSON.stringify(curationListObject, undefined, 4);
+const toolListJSONJSON = JSON.stringify(toolListObject, undefined, 4);
+
+const curationListActual = fs.readFileSync(
+  "./lists/curations-0.16.json",
+  "utf-8"
+);
+const toolListActual = fs.readFileSync("./lists/tool-list-0.16.json", "utf-8");
+
+if (curationListJSON !== curationListActual)
+  throw new Error(
+    "Invalid curation list. List does not match the list defined in ./lists/curations-0.16.ts"
+  );
+if (toolListJSONJSON !== toolListActual)
+  throw new Error(
+    "Invalid developer collective Tools list. List does not match the list defined in ./lists/tool-list-0.16.ts"
+  );
+
+
+let webhappUrls = new Set();
+
+// Check each tool
+toolListObject.tools.forEach((tool) => {
+  // Check Icon URL
+  try {
+    const _iconUrl = new URL(tool.icon);
+  } catch (e) {
+    throw new Error(`Invalid icon URL for tool '${tool.title}' `);
+  }
+  // Check each version
+  tool.versions.forEach((versionInfo) => {
+    // Check version field is valid semver
+    if (!semver.valid(versionInfo.version))
+      throw new Error(
+        `Found invalid semver version ${versionInfo.version} for tool '${tool.title} ${tool.versionBranch}'`
+      );
+
+    // Check releasedAt timestamp
+    if (
+      versionInfo.releasedAt < 1711978174000 ||
+      versionInfo.releasedAt > 2690198974000
+    ) {
+      throw new Error(
+        `Invalid releasedAt timestamp ${versionInfo.releasedAt} for tool '${tool.title} ${versionInfo.version}'.
+         Timestamps must be in milliseconds unix epoch time.`
+      );
+    }
+
+    // Check webhapp URL
+    if (webhappUrls.has(versionInfo.url)) {
+      throw new Error(`Duplicate use of webhapp url ${versionInfo.url} for tool '${tool.title} ${versionInfo.version}'`);
+    }
+    webhappUrls.add(versionInfo.url);
+    if (!versionInfo.url.toLowerCase().endsWith(".webhapp")) {
+      throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
+    }
+    try {
+      const _url = new URL(versionInfo.url);
+    } catch (e) {
+      throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
+    }
+
+    // Make sure each hash is different
+    if (versionInfo.hashes.happSha256 === versionInfo.hashes.webhappSha256
+        || versionInfo.hashes.happSha256 === versionInfo.hashes.uiSha256
+        || versionInfo.hashes.uiSha256 === versionInfo.hashes.webhappSha256) {
+      throw new Error(`Found identical hashes for tool '${tool.title} ${versionInfo.version}'`);
+    }
+
+  });
+});
+
+// Verify that versionBranch fields are unique for the same tool id
+const idsAndBranches = toolListObject.tools.map(
+  (tool) => `${tool.id}#${tool.versionBranch}`
+);
+if (Array.from(new Set(idsAndBranches)).length !== idsAndBranches.length)
+  throw new Error(
+    "Tool list contains at least two Tools that have the same id and versionBranch. This is not allowed."
+  );
+
+// Verify that happ sha256 are the same for tools in the same versionBranch
+toolListObject.tools.forEach((toolInfo) => {
+  if (
+    Array.from(
+      new Set(
+        toolInfo.versions.map((versionInfo) => versionInfo.hashes.happSha256)
+      )
+    ).length > 1
+  )
+    throw new Error(
+      `happSha256 are not unique for tool ${toolInfo.title} and verisonBranch ${toolInfo.versionBranch}`
+    );
+});
+

--- a/0.16/write-collective-list.js
+++ b/0.16/write-collective-list.js
@@ -1,0 +1,4 @@
+import fs from 'fs';
+import  toolListObject from './modify/tool-list-0.16.ts';
+const toolListJSON = JSON.stringify(toolListObject, undefined, 4);
+fs.writeFileSync('./lists/tool-list-0.16.json', toolListJSON);

--- a/0.16/write-curation-list.js
+++ b/0.16/write-curation-list.js
@@ -1,0 +1,4 @@
+import fs from 'fs';
+import curationListObject from './modify/curations-0.16.ts';
+const curationListJSON = JSON.stringify(curationListObject, undefined, 4);
+fs.writeFileSync('./lists/curations-0.16.json', curationListJSON);


### PR DESCRIPTION
Scaffolds the 0.16 tool-curation folder from 0.15, depending on @theweave/moss-types 0.5.4. Lists contain only the ZipTest tool (0.5.0-dev.0) for the Holochain 0.7 line; all other tools dropped as incompatible.