### PR TITLE
Add 0.15/0.16 dev curation lists; move ziptest to production 0.16 at 0.6.0-dev.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,8 +50,12 @@ jobs:
           cp ./0.14/lists/tool-list-0.14.json ./static/0.14
           cp ./0.15/lists/curations-0.15.json ./static/0.15
           cp ./0.15/lists/tool-list-0.15.json ./static/0.15
+          cp ./0.15/lists/curations-dev-0.15.json ./static/0.15
+          cp ./0.15/lists/tool-list-dev-0.15.json ./static/0.15
           cp ./0.16/lists/curations-0.16.json ./static/0.16
           cp ./0.16/lists/tool-list-0.16.json ./static/0.16
+          cp ./0.16/lists/curations-dev-0.16.json ./static/0.16
+          cp ./0.16/lists/tool-list-dev-0.16.json ./static/0.16
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/0.15/README.md
+++ b/0.15/README.md
@@ -45,3 +45,27 @@ and they need to match with how Moss computes them.
 3. run `npm run test` to run basic validity checks for the generated json file.
 4. Make a PR with the new change
 
+## Dev Curation List
+
+Alongside the stable lists, this folder also contains a separate **dev** curation list and dev
+Tools list for publishing in-development builds:
+
+- Source: `./modify/curations-dev-0.15.ts` and `./modify/tool-list-dev-0.15.ts`
+- Generated: `./lists/curations-dev-0.15.json` and `./lists/tool-list-dev-0.15.json`
+- Deployed:
+  - `https://lightningrodlabs.org/weave-tool-curation/0.15/curations-dev-0.15.json`
+  - `https://lightningrodlabs.org/weave-tool-curation/0.15/tool-list-dev-0.15.json`
+
+The dev list is a **separate curation source**: it is not part of the default Lightningrod Labs
+curation. To see the dev Tools in Moss, add the dev curations URL above as an additional curation
+list in Moss. Users who do not add it never see the dev Tools.
+
+To modify the dev lists, edit the `*-dev-0.15.ts` files and run `npm run write-lists` (which
+regenerates and validates both the stable and dev lists), then make a PR.
+
+> [!WARNING]
+> Dev versions are unstable and may break or change without notice. Publish multiple
+> in-development builds under distinct semver versions (e.g. `0.5.0-dev.0`, `0.5.0-dev.1`). The dev
+> list intentionally relaxes the "same `happSha256` across a versionBranch" check that the stable
+> list enforces, since the happ legitimately changes between dev builds.
+

--- a/0.15/lists/curations-dev-0.15.json
+++ b/0.15/lists/curations-dev-0.15.json
@@ -1,0 +1,20 @@
+{
+    "curator": {
+        "name": "Lightningrod Labs (Dev)",
+        "description": "In-development Tools from Lightningrod Labs. Versions in this list are unstable, may break, and may change or disappear without notice. Not for production use.",
+        "contact": {
+            "website": "https://lightningrodlabs.org"
+        },
+        "icon": "https://lightningrodlabs.org/lrl_logo.png"
+    },
+    "curationLists": {
+        "default": {
+            "name": "Dev Curation List",
+            "description": "Curation List of in-development Tools from Lightningrod Labs (Moss 0.15)",
+            "tags": [
+                "dev"
+            ],
+            "tools": []
+        }
+    }
+}

--- a/0.15/lists/tool-list-dev-0.15.json
+++ b/0.15/lists/tool-list-dev-0.15.json
@@ -1,0 +1,12 @@
+{
+    "developerCollective": {
+        "id": "lightningrodlabs-dev",
+        "name": "Lightningrod Labs (Dev)",
+        "description": "In-development builds from Lightningrod Labs. Unstable and subject to change.",
+        "icon": "https://lightningrodlabs.org/lrl_logo.png",
+        "contact": {
+            "website": "https://lightningrodlabs.org"
+        }
+    },
+    "tools": []
+}

--- a/0.15/modify/curations-dev-0.15.ts
+++ b/0.15/modify/curations-dev-0.15.ts
@@ -1,0 +1,22 @@
+import { defineCurationLists } from "@theweave/moss-types";
+
+export default defineCurationLists({
+  curator: {
+    name: "Lightningrod Labs (Dev)",
+    description:
+      "In-development Tools from Lightningrod Labs. Versions in this list are unstable, may break, and may change or disappear without notice. Not for production use.",
+    contact: {
+      website: "https://lightningrodlabs.org",
+    },
+    icon: "https://lightningrodlabs.org/lrl_logo.png",
+  },
+  curationLists: {
+    default: {
+      name: "Dev Curation List",
+      description:
+        "Curation List of in-development Tools from Lightningrod Labs (Moss 0.15)",
+      tags: ["dev"],
+      tools: [],
+    },
+  },
+});

--- a/0.15/modify/tool-list-dev-0.15.ts
+++ b/0.15/modify/tool-list-dev-0.15.ts
@@ -1,0 +1,15 @@
+import { defineDevCollectiveToolList } from "@theweave/moss-types";
+
+export default defineDevCollectiveToolList({
+  developerCollective: {
+    id: "lightningrodlabs-dev",
+    name: "Lightningrod Labs (Dev)",
+    description:
+      "In-development builds from Lightningrod Labs. Unstable and subject to change.",
+    icon: "https://lightningrodlabs.org/lrl_logo.png",
+    contact: {
+      website: "https://lightningrodlabs.org",
+    },
+  },
+  tools: [],
+});

--- a/0.15/package.json
+++ b/0.15/package.json
@@ -6,7 +6,9 @@
     "test": "node --loader ts-node/esm ./validate-lists.js",
     "write-curation-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-curation-list.js",
     "write-collective-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-collective-list.js",
-    "write-lists": "npm run write-curation-list && npm run write-collective-list && npm run test"
+    "write-dev-curation-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-dev-curation-list.js",
+    "write-dev-collective-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-dev-collective-list.js",
+    "write-lists": "npm run write-curation-list && npm run write-collective-list && npm run write-dev-curation-list && npm run write-dev-collective-list && npm run test"
   },
   "author": "",
   "license": "ISC",

--- a/0.15/validate-lists.js
+++ b/0.15/validate-lists.js
@@ -1,99 +1,135 @@
 import fs from "fs";
 import semver from "semver";
+
 import curationListObject from "./modify/curations-0.15.ts";
 import toolListObject from "./modify/tool-list-0.15.ts";
-const curationListJSON = JSON.stringify(curationListObject, undefined, 4);
-const toolListJSONJSON = JSON.stringify(toolListObject, undefined, 4);
+import devCurationListObject from "./modify/curations-dev-0.15.ts";
+import devToolListObject from "./modify/tool-list-dev-0.15.ts";
 
-const curationListActual = fs.readFileSync(
-  "./lists/curations-0.15.json",
-  "utf-8"
-);
-const toolListActual = fs.readFileSync("./lists/tool-list-0.15.json", "utf-8");
+function validatePair({
+  label,
+  curationListObject,
+  toolListObject,
+  curationListFile,
+  toolListFile,
+  curationListSource,
+  toolListSource,
+  // Dev lists publish multiple in-development builds on the same versionBranch,
+  // and the happ legitimately changes between those builds, so the
+  // same-branch-same-happ invariant is only enforced for stable lists.
+  enforceSameHappPerBranch = true,
+}) {
+  const curationListJSON = JSON.stringify(curationListObject, undefined, 4);
+  const toolListJSON = JSON.stringify(toolListObject, undefined, 4);
 
-if (curationListJSON !== curationListActual)
-  throw new Error(
-    "Invalid curation list. List does not match the list defined in ./lists/curations-0.15.ts"
-  );
-if (toolListJSONJSON !== toolListActual)
-  throw new Error(
-    "Invalid developer collective Tools list. List does not match the list defined in ./lists/tool-list-0.15.ts"
-  );
+  const curationListActual = fs.readFileSync(curationListFile, "utf-8");
+  const toolListActual = fs.readFileSync(toolListFile, "utf-8");
 
-
-let webhappUrls = new Set();
-
-// Check each tool
-toolListObject.tools.forEach((tool) => {
-  // Check Icon URL
-  try {
-    const _iconUrl = new URL(tool.icon);
-  } catch (e) {
-    throw new Error(`Invalid icon URL for tool '${tool.title}' `);
-  }
-  // Check each version
-  tool.versions.forEach((versionInfo) => {
-    // Check version field is valid semver
-    if (!semver.valid(versionInfo.version))
-      throw new Error(
-        `Found invalid semver version ${versionInfo.version} for tool '${tool.title} ${tool.versionBranch}'`
-      );
-
-    // Check releasedAt timestamp
-    if (
-      versionInfo.releasedAt < 1711978174000 ||
-      versionInfo.releasedAt > 2690198974000
-    ) {
-      throw new Error(
-        `Invalid releasedAt timestamp ${versionInfo.releasedAt} for tool '${tool.title} ${versionInfo.version}'.
-         Timestamps must be in milliseconds unix epoch time.`
-      );
-    }
-
-    // Check webhapp URL
-    if (webhappUrls.has(versionInfo.url)) {
-      throw new Error(`Duplicate use of webhapp url ${versionInfo.url} for tool '${tool.title} ${versionInfo.version}'`);
-    }
-    webhappUrls.add(versionInfo.url);
-    if (!versionInfo.url.toLowerCase().endsWith(".webhapp")) {
-      throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
-    }
-    try {
-      const _url = new URL(versionInfo.url);
-    } catch (e) {
-      throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
-    }
-
-    // Make sure each hash is different
-    if (versionInfo.hashes.happSha256 === versionInfo.hashes.webhappSha256
-        || versionInfo.hashes.happSha256 === versionInfo.hashes.uiSha256
-        || versionInfo.hashes.uiSha256 === versionInfo.hashes.webhappSha256) {
-      throw new Error(`Found identical hashes for tool '${tool.title} ${versionInfo.version}'`);
-    }
-
-  });
-});
-
-// Verify that versionBranch fields are unique for the same tool id
-const idsAndBranches = toolListObject.tools.map(
-  (tool) => `${tool.id}#${tool.versionBranch}`
-);
-if (Array.from(new Set(idsAndBranches)).length !== idsAndBranches.length)
-  throw new Error(
-    "Tool list contains at least two Tools that have the same id and versionBranch. This is not allowed."
-  );
-
-// Verify that happ sha256 are the same for tools in the same versionBranch
-toolListObject.tools.forEach((toolInfo) => {
-  if (
-    Array.from(
-      new Set(
-        toolInfo.versions.map((versionInfo) => versionInfo.hashes.happSha256)
-      )
-    ).length > 1
-  )
+  if (curationListJSON !== curationListActual)
     throw new Error(
-      `happSha256 are not unique for tool ${toolInfo.title} and verisonBranch ${toolInfo.versionBranch}`
+      `Invalid ${label} curation list. List does not match the list defined in ${curationListSource}`
     );
+  if (toolListJSON !== toolListActual)
+    throw new Error(
+      `Invalid ${label} developer collective Tools list. List does not match the list defined in ${toolListSource}`
+    );
+
+  let webhappUrls = new Set();
+
+  // Check each tool
+  toolListObject.tools.forEach((tool) => {
+    // Check Icon URL
+    try {
+      const _iconUrl = new URL(tool.icon);
+    } catch (e) {
+      throw new Error(`Invalid icon URL for tool '${tool.title}' `);
+    }
+    // Check each version
+    tool.versions.forEach((versionInfo) => {
+      // Check version field is valid semver
+      if (!semver.valid(versionInfo.version))
+        throw new Error(
+          `Found invalid semver version ${versionInfo.version} for tool '${tool.title} ${tool.versionBranch}'`
+        );
+
+      // Check releasedAt timestamp
+      if (
+        versionInfo.releasedAt < 1711978174000 ||
+        versionInfo.releasedAt > 2690198974000
+      ) {
+        throw new Error(
+          `Invalid releasedAt timestamp ${versionInfo.releasedAt} for tool '${tool.title} ${versionInfo.version}'.
+           Timestamps must be in milliseconds unix epoch time.`
+        );
+      }
+
+      // Check webhapp URL
+      if (webhappUrls.has(versionInfo.url)) {
+        throw new Error(`Duplicate use of webhapp url ${versionInfo.url} for tool '${tool.title} ${versionInfo.version}'`);
+      }
+      webhappUrls.add(versionInfo.url);
+      if (!versionInfo.url.toLowerCase().endsWith(".webhapp")) {
+        throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
+      }
+      try {
+        const _url = new URL(versionInfo.url);
+      } catch (e) {
+        throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
+      }
+
+      // Make sure each hash is different
+      if (versionInfo.hashes.happSha256 === versionInfo.hashes.webhappSha256
+          || versionInfo.hashes.happSha256 === versionInfo.hashes.uiSha256
+          || versionInfo.hashes.uiSha256 === versionInfo.hashes.webhappSha256) {
+        throw new Error(`Found identical hashes for tool '${tool.title} ${versionInfo.version}'`);
+      }
+
+    });
+  });
+
+  // Verify that versionBranch fields are unique for the same tool id
+  const idsAndBranches = toolListObject.tools.map(
+    (tool) => `${tool.id}#${tool.versionBranch}`
+  );
+  if (Array.from(new Set(idsAndBranches)).length !== idsAndBranches.length)
+    throw new Error(
+      "Tool list contains at least two Tools that have the same id and versionBranch. This is not allowed."
+    );
+
+  // Verify that happ sha256 are the same for tools in the same versionBranch
+  if (enforceSameHappPerBranch) {
+    toolListObject.tools.forEach((toolInfo) => {
+      if (
+        Array.from(
+          new Set(
+            toolInfo.versions.map((versionInfo) => versionInfo.hashes.happSha256)
+          )
+        ).length > 1
+      )
+        throw new Error(
+          `happSha256 are not unique for tool ${toolInfo.title} and verisonBranch ${toolInfo.versionBranch}`
+        );
+    });
+  }
+}
+
+validatePair({
+  label: "stable",
+  curationListObject,
+  toolListObject,
+  curationListFile: "./lists/curations-0.15.json",
+  toolListFile: "./lists/tool-list-0.15.json",
+  curationListSource: "./modify/curations-0.15.ts",
+  toolListSource: "./modify/tool-list-0.15.ts",
 });
 
+validatePair({
+  label: "dev",
+  curationListObject: devCurationListObject,
+  toolListObject: devToolListObject,
+  curationListFile: "./lists/curations-dev-0.15.json",
+  toolListFile: "./lists/tool-list-dev-0.15.json",
+  curationListSource: "./modify/curations-dev-0.15.ts",
+  toolListSource: "./modify/tool-list-dev-0.15.ts",
+  enforceSameHappPerBranch: false,
+});

--- a/0.15/write-dev-collective-list.js
+++ b/0.15/write-dev-collective-list.js
@@ -1,0 +1,4 @@
+import fs from 'fs';
+import toolListObject from './modify/tool-list-dev-0.15.ts';
+const toolListJSON = JSON.stringify(toolListObject, undefined, 4);
+fs.writeFileSync('./lists/tool-list-dev-0.15.json', toolListJSON);

--- a/0.15/write-dev-curation-list.js
+++ b/0.15/write-dev-curation-list.js
@@ -1,0 +1,4 @@
+import fs from 'fs';
+import curationListObject from './modify/curations-dev-0.15.ts';
+const curationListJSON = JSON.stringify(curationListObject, undefined, 4);
+fs.writeFileSync('./lists/curations-dev-0.15.json', curationListJSON);

--- a/0.16/README.md
+++ b/0.16/README.md
@@ -45,3 +45,27 @@ and they need to match with how Moss computes them.
 3. run `npm run test` to run basic validity checks for the generated json file.
 4. Make a PR with the new change
 
+## Dev Curation List
+
+Alongside the stable lists, this folder also contains a separate **dev** curation list and dev
+Tools list for publishing in-development builds:
+
+- Source: `./modify/curations-dev-0.16.ts` and `./modify/tool-list-dev-0.16.ts`
+- Generated: `./lists/curations-dev-0.16.json` and `./lists/tool-list-dev-0.16.json`
+- Deployed:
+  - `https://lightningrodlabs.org/weave-tool-curation/0.16/curations-dev-0.16.json`
+  - `https://lightningrodlabs.org/weave-tool-curation/0.16/tool-list-dev-0.16.json`
+
+The dev list is a **separate curation source**: it is not part of the default Lightningrod Labs
+curation. To see the dev Tools in Moss, add the dev curations URL above as an additional curation
+list in Moss. Users who do not add it never see the dev Tools.
+
+To modify the dev lists, edit the `*-dev-0.16.ts` files and run `npm run write-lists` (which
+regenerates and validates both the stable and dev lists), then make a PR.
+
+> [!WARNING]
+> Dev versions are unstable and may break or change without notice. Publish multiple
+> in-development builds under distinct semver versions (e.g. `0.5.0-dev.0`, `0.5.0-dev.1`). The dev
+> list intentionally relaxes the "same `happSha256` across a versionBranch" check that the stable
+> list enforces, since the happ legitimately changes between dev builds.
+

--- a/0.16/lists/curations-0.16.json
+++ b/0.16/lists/curations-0.16.json
@@ -16,7 +16,7 @@
                 {
                     "toolListUrl": "https://lightningrodlabs.org/weave-tool-curation/0.16/tool-list-0.16.json",
                     "toolId": "ziptest",
-                    "versionBranch": "0.5.x",
+                    "versionBranch": "0.6.x",
                     "tags": [
                         "testing"
                     ],

--- a/0.16/lists/curations-dev-0.16.json
+++ b/0.16/lists/curations-dev-0.16.json
@@ -1,0 +1,31 @@
+{
+    "curator": {
+        "name": "Lightningrod Labs (Dev)",
+        "description": "In-development Tools from Lightningrod Labs. Versions in this list are unstable, may break, and may change or disappear without notice. Not for production use.",
+        "contact": {
+            "website": "https://lightningrodlabs.org"
+        },
+        "icon": "https://lightningrodlabs.org/lrl_logo.png"
+    },
+    "curationLists": {
+        "default": {
+            "name": "Dev Curation List",
+            "description": "Curation List of in-development Tools from Lightningrod Labs (Moss 0.16)",
+            "tags": [
+                "dev"
+            ],
+            "tools": [
+                {
+                    "toolListUrl": "https://lightningrodlabs.org/weave-tool-curation/0.16/tool-list-dev-0.16.json",
+                    "toolId": "ziptest",
+                    "versionBranch": "0.5.x",
+                    "tags": [
+                        "testing",
+                        "dev"
+                    ],
+                    "visiblity": "low"
+                }
+            ]
+        }
+    }
+}

--- a/0.16/lists/curations-dev-0.16.json
+++ b/0.16/lists/curations-dev-0.16.json
@@ -14,18 +14,7 @@
             "tags": [
                 "dev"
             ],
-            "tools": [
-                {
-                    "toolListUrl": "https://lightningrodlabs.org/weave-tool-curation/0.16/tool-list-dev-0.16.json",
-                    "toolId": "ziptest",
-                    "versionBranch": "0.5.x",
-                    "tags": [
-                        "testing",
-                        "dev"
-                    ],
-                    "visiblity": "low"
-                }
-            ]
+            "tools": []
         }
     }
 }

--- a/0.16/lists/tool-list-0.16.json
+++ b/0.16/lists/tool-list-0.16.json
@@ -11,7 +11,7 @@
     "tools": [
         {
             "id": "ziptest",
-            "versionBranch": "0.5.x",
+            "versionBranch": "0.6.x",
             "title": "ZipTest",
             "subtitle": "Simple performance testing",
             "description": "Send batches of signals and watch acks com back.  Create entries and watch how long it takes for them to propagate.",
@@ -21,15 +21,15 @@
             ],
             "versions": [
                 {
-                    "version": "0.5.0-dev.0",
+                    "version": "0.6.0-dev.0",
                     "hashes": {
-                        "happSha256": "06d6957ff2812e16f3707315f6ea397260cc2bec690eaba9522b6f30755e8085",
-                        "webhappSha256": "f49b368096c2ac4f40a78e1ce56d5cf507331efbe6779d927b17ac44650ee079",
-                        "uiSha256": "8ed9f60e5eaa484bc350a133cfe4045ccb65b87593c742d44218c1244b1fe0c8"
+                        "happSha256": "4da017a73dee5e857448b9075a801e23029ab58d4acee50a1f9ae6d7557bb8f3",
+                        "webhappSha256": "271367169b5ab3e8ec73ae8bd9118b841d000733a5315fbf39dbd0c7a27bde1e",
+                        "uiSha256": "5482b628a3ebf2189ea27897471b6a5bb691f9c87290245524b7f3cece3090dd"
                     },
-                    "url": "https://github.com/holochain/ziptest/releases/download/v0.5.0-dev.0/ziptest.webhapp",
-                    "changelog": "Update to holochain 0.7 line",
-                    "releasedAt": 1779219790524
+                    "url": "https://github.com/holochain/ziptest/releases/download/v0.6.0-dev.0/ziptest.webhapp",
+                    "changelog": "Update to Holochain 0.7.0",
+                    "releasedAt": 1785789192013
                 }
             ]
         }

--- a/0.16/lists/tool-list-dev-0.16.json
+++ b/0.16/lists/tool-list-dev-0.16.json
@@ -1,0 +1,38 @@
+{
+    "developerCollective": {
+        "id": "lightningrodlabs-dev",
+        "name": "Lightningrod Labs (Dev)",
+        "description": "In-development builds from Lightningrod Labs. Unstable and subject to change.",
+        "icon": "https://lightningrodlabs.org/lrl_logo.png",
+        "contact": {
+            "website": "https://lightningrodlabs.org"
+        }
+    },
+    "tools": [
+        {
+            "id": "ziptest",
+            "versionBranch": "0.5.x",
+            "title": "ZipTest",
+            "subtitle": "Simple performance testing",
+            "description": "Send batches of signals and watch acks com back.  Create entries and watch how long it takes for them to propagate.",
+            "icon": "https://github.com/holochain/ziptest/releases/download/ziptest-v0.3.0/ziptest_icon.png",
+            "tags": [
+                "testing",
+                "dev"
+            ],
+            "versions": [
+                {
+                    "version": "0.5.0-dev.0",
+                    "hashes": {
+                        "happSha256": "06d6957ff2812e16f3707315f6ea397260cc2bec690eaba9522b6f30755e8085",
+                        "webhappSha256": "f49b368096c2ac4f40a78e1ce56d5cf507331efbe6779d927b17ac44650ee079",
+                        "uiSha256": "8ed9f60e5eaa484bc350a133cfe4045ccb65b87593c742d44218c1244b1fe0c8"
+                    },
+                    "url": "https://github.com/holochain/ziptest/releases/download/v0.5.0-dev.0/ziptest.webhapp",
+                    "changelog": "Update to holochain 0.7 line",
+                    "releasedAt": 1779219790524
+                }
+            ]
+        }
+    ]
+}

--- a/0.16/lists/tool-list-dev-0.16.json
+++ b/0.16/lists/tool-list-dev-0.16.json
@@ -8,31 +8,5 @@
             "website": "https://lightningrodlabs.org"
         }
     },
-    "tools": [
-        {
-            "id": "ziptest",
-            "versionBranch": "0.5.x",
-            "title": "ZipTest",
-            "subtitle": "Simple performance testing",
-            "description": "Send batches of signals and watch acks com back.  Create entries and watch how long it takes for them to propagate.",
-            "icon": "https://github.com/holochain/ziptest/releases/download/ziptest-v0.3.0/ziptest_icon.png",
-            "tags": [
-                "testing",
-                "dev"
-            ],
-            "versions": [
-                {
-                    "version": "0.5.0-dev.0",
-                    "hashes": {
-                        "happSha256": "06d6957ff2812e16f3707315f6ea397260cc2bec690eaba9522b6f30755e8085",
-                        "webhappSha256": "f49b368096c2ac4f40a78e1ce56d5cf507331efbe6779d927b17ac44650ee079",
-                        "uiSha256": "8ed9f60e5eaa484bc350a133cfe4045ccb65b87593c742d44218c1244b1fe0c8"
-                    },
-                    "url": "https://github.com/holochain/ziptest/releases/download/v0.5.0-dev.0/ziptest.webhapp",
-                    "changelog": "Update to holochain 0.7 line",
-                    "releasedAt": 1779219790524
-                }
-            ]
-        }
-    ]
+    "tools": []
 }

--- a/0.16/modify/curations-0.16.ts
+++ b/0.16/modify/curations-0.16.ts
@@ -19,7 +19,7 @@ export default defineCurationLists({
           toolListUrl:
             "https://lightningrodlabs.org/weave-tool-curation/0.16/tool-list-0.16.json",
           toolId: "ziptest",
-          versionBranch: "0.5.x",
+          versionBranch: "0.6.x",
           tags: ["testing"],
           visiblity: "low",
         },

--- a/0.16/modify/curations-dev-0.16.ts
+++ b/0.16/modify/curations-dev-0.16.ts
@@ -1,0 +1,31 @@
+import { defineCurationLists } from "@theweave/moss-types";
+
+export default defineCurationLists({
+  curator: {
+    name: "Lightningrod Labs (Dev)",
+    description:
+      "In-development Tools from Lightningrod Labs. Versions in this list are unstable, may break, and may change or disappear without notice. Not for production use.",
+    contact: {
+      website: "https://lightningrodlabs.org",
+    },
+    icon: "https://lightningrodlabs.org/lrl_logo.png",
+  },
+  curationLists: {
+    default: {
+      name: "Dev Curation List",
+      description:
+        "Curation List of in-development Tools from Lightningrod Labs (Moss 0.16)",
+      tags: ["dev"],
+      tools: [
+        {
+          toolListUrl:
+            "https://lightningrodlabs.org/weave-tool-curation/0.16/tool-list-dev-0.16.json",
+          toolId: "ziptest",
+          versionBranch: "0.5.x",
+          tags: ["testing", "dev"],
+          visiblity: "low",
+        },
+      ],
+    },
+  },
+});

--- a/0.16/modify/curations-dev-0.16.ts
+++ b/0.16/modify/curations-dev-0.16.ts
@@ -16,16 +16,7 @@ export default defineCurationLists({
       description:
         "Curation List of in-development Tools from Lightningrod Labs (Moss 0.16)",
       tags: ["dev"],
-      tools: [
-        {
-          toolListUrl:
-            "https://lightningrodlabs.org/weave-tool-curation/0.16/tool-list-dev-0.16.json",
-          toolId: "ziptest",
-          versionBranch: "0.5.x",
-          tags: ["testing", "dev"],
-          visiblity: "low",
-        },
-      ],
+      tools: [],
     },
   },
 });

--- a/0.16/modify/tool-list-0.16.ts
+++ b/0.16/modify/tool-list-0.16.ts
@@ -13,7 +13,7 @@ export default defineDevCollectiveToolList({
   tools: [
     {
       id: "ziptest",
-      versionBranch: "0.5.x",
+      versionBranch: "0.6.x",
       title: "ZipTest",
       subtitle: "Simple performance testing",
       description:
@@ -22,18 +22,18 @@ export default defineDevCollectiveToolList({
       tags: ["testing"],
       versions: [
         {
-          version: "0.5.0-dev.0",
+          version: "0.6.0-dev.0",
           hashes: {
             happSha256:
-              "06d6957ff2812e16f3707315f6ea397260cc2bec690eaba9522b6f30755e8085",
+              "4da017a73dee5e857448b9075a801e23029ab58d4acee50a1f9ae6d7557bb8f3",
             webhappSha256:
-              "f49b368096c2ac4f40a78e1ce56d5cf507331efbe6779d927b17ac44650ee079",
+              "271367169b5ab3e8ec73ae8bd9118b841d000733a5315fbf39dbd0c7a27bde1e",
             uiSha256:
-              "8ed9f60e5eaa484bc350a133cfe4045ccb65b87593c742d44218c1244b1fe0c8",
+              "5482b628a3ebf2189ea27897471b6a5bb691f9c87290245524b7f3cece3090dd",
           },
-          url: "https://github.com/holochain/ziptest/releases/download/v0.5.0-dev.0/ziptest.webhapp",
-          changelog: "Update to holochain 0.7 line",
-          releasedAt: 1779219790524,
+          url: "https://github.com/holochain/ziptest/releases/download/v0.6.0-dev.0/ziptest.webhapp",
+          changelog: "Update to Holochain 0.7.0",
+          releasedAt: 1785789192013,
         },
       ],
     },

--- a/0.16/modify/tool-list-dev-0.16.ts
+++ b/0.16/modify/tool-list-dev-0.16.ts
@@ -1,0 +1,42 @@
+import { defineDevCollectiveToolList } from "@theweave/moss-types";
+
+export default defineDevCollectiveToolList({
+  developerCollective: {
+    id: "lightningrodlabs-dev",
+    name: "Lightningrod Labs (Dev)",
+    description:
+      "In-development builds from Lightningrod Labs. Unstable and subject to change.",
+    icon: "https://lightningrodlabs.org/lrl_logo.png",
+    contact: {
+      website: "https://lightningrodlabs.org",
+    },
+  },
+  tools: [
+    {
+      id: "ziptest",
+      versionBranch: "0.5.x",
+      title: "ZipTest",
+      subtitle: "Simple performance testing",
+      description:
+        "Send batches of signals and watch acks com back.  Create entries and watch how long it takes for them to propagate.",
+      icon: "https://github.com/holochain/ziptest/releases/download/ziptest-v0.3.0/ziptest_icon.png",
+      tags: ["testing", "dev"],
+      versions: [
+        {
+          version: "0.5.0-dev.0",
+          hashes: {
+            happSha256:
+              "06d6957ff2812e16f3707315f6ea397260cc2bec690eaba9522b6f30755e8085",
+            webhappSha256:
+              "f49b368096c2ac4f40a78e1ce56d5cf507331efbe6779d927b17ac44650ee079",
+            uiSha256:
+              "8ed9f60e5eaa484bc350a133cfe4045ccb65b87593c742d44218c1244b1fe0c8",
+          },
+          url: "https://github.com/holochain/ziptest/releases/download/v0.5.0-dev.0/ziptest.webhapp",
+          changelog: "Update to holochain 0.7 line",
+          releasedAt: 1779219790524,
+        },
+      ],
+    },
+  ],
+});

--- a/0.16/modify/tool-list-dev-0.16.ts
+++ b/0.16/modify/tool-list-dev-0.16.ts
@@ -11,32 +11,5 @@ export default defineDevCollectiveToolList({
       website: "https://lightningrodlabs.org",
     },
   },
-  tools: [
-    {
-      id: "ziptest",
-      versionBranch: "0.5.x",
-      title: "ZipTest",
-      subtitle: "Simple performance testing",
-      description:
-        "Send batches of signals and watch acks com back.  Create entries and watch how long it takes for them to propagate.",
-      icon: "https://github.com/holochain/ziptest/releases/download/ziptest-v0.3.0/ziptest_icon.png",
-      tags: ["testing", "dev"],
-      versions: [
-        {
-          version: "0.5.0-dev.0",
-          hashes: {
-            happSha256:
-              "06d6957ff2812e16f3707315f6ea397260cc2bec690eaba9522b6f30755e8085",
-            webhappSha256:
-              "f49b368096c2ac4f40a78e1ce56d5cf507331efbe6779d927b17ac44650ee079",
-            uiSha256:
-              "8ed9f60e5eaa484bc350a133cfe4045ccb65b87593c742d44218c1244b1fe0c8",
-          },
-          url: "https://github.com/holochain/ziptest/releases/download/v0.5.0-dev.0/ziptest.webhapp",
-          changelog: "Update to holochain 0.7 line",
-          releasedAt: 1779219790524,
-        },
-      ],
-    },
-  ],
+  tools: [],
 });

--- a/0.16/package.json
+++ b/0.16/package.json
@@ -6,7 +6,9 @@
     "test": "node --loader ts-node/esm ./validate-lists.js",
     "write-curation-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-curation-list.js",
     "write-collective-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-collective-list.js",
-    "write-lists": "npm run write-curation-list && npm run write-collective-list && npm run test"
+    "write-dev-curation-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-dev-curation-list.js",
+    "write-dev-collective-list": "node --loader ts-node/esm --abort-on-uncaught-exception ./write-dev-collective-list.js",
+    "write-lists": "npm run write-curation-list && npm run write-collective-list && npm run write-dev-curation-list && npm run write-dev-collective-list && npm run test"
   },
   "author": "",
   "license": "ISC",

--- a/0.16/validate-lists.js
+++ b/0.16/validate-lists.js
@@ -1,99 +1,135 @@
 import fs from "fs";
 import semver from "semver";
+
 import curationListObject from "./modify/curations-0.16.ts";
 import toolListObject from "./modify/tool-list-0.16.ts";
-const curationListJSON = JSON.stringify(curationListObject, undefined, 4);
-const toolListJSONJSON = JSON.stringify(toolListObject, undefined, 4);
+import devCurationListObject from "./modify/curations-dev-0.16.ts";
+import devToolListObject from "./modify/tool-list-dev-0.16.ts";
 
-const curationListActual = fs.readFileSync(
-  "./lists/curations-0.16.json",
-  "utf-8"
-);
-const toolListActual = fs.readFileSync("./lists/tool-list-0.16.json", "utf-8");
+function validatePair({
+  label,
+  curationListObject,
+  toolListObject,
+  curationListFile,
+  toolListFile,
+  curationListSource,
+  toolListSource,
+  // Dev lists publish multiple in-development builds on the same versionBranch,
+  // and the happ legitimately changes between those builds, so the
+  // same-branch-same-happ invariant is only enforced for stable lists.
+  enforceSameHappPerBranch = true,
+}) {
+  const curationListJSON = JSON.stringify(curationListObject, undefined, 4);
+  const toolListJSON = JSON.stringify(toolListObject, undefined, 4);
 
-if (curationListJSON !== curationListActual)
-  throw new Error(
-    "Invalid curation list. List does not match the list defined in ./lists/curations-0.16.ts"
-  );
-if (toolListJSONJSON !== toolListActual)
-  throw new Error(
-    "Invalid developer collective Tools list. List does not match the list defined in ./lists/tool-list-0.16.ts"
-  );
+  const curationListActual = fs.readFileSync(curationListFile, "utf-8");
+  const toolListActual = fs.readFileSync(toolListFile, "utf-8");
 
-
-let webhappUrls = new Set();
-
-// Check each tool
-toolListObject.tools.forEach((tool) => {
-  // Check Icon URL
-  try {
-    const _iconUrl = new URL(tool.icon);
-  } catch (e) {
-    throw new Error(`Invalid icon URL for tool '${tool.title}' `);
-  }
-  // Check each version
-  tool.versions.forEach((versionInfo) => {
-    // Check version field is valid semver
-    if (!semver.valid(versionInfo.version))
-      throw new Error(
-        `Found invalid semver version ${versionInfo.version} for tool '${tool.title} ${tool.versionBranch}'`
-      );
-
-    // Check releasedAt timestamp
-    if (
-      versionInfo.releasedAt < 1711978174000 ||
-      versionInfo.releasedAt > 2690198974000
-    ) {
-      throw new Error(
-        `Invalid releasedAt timestamp ${versionInfo.releasedAt} for tool '${tool.title} ${versionInfo.version}'.
-         Timestamps must be in milliseconds unix epoch time.`
-      );
-    }
-
-    // Check webhapp URL
-    if (webhappUrls.has(versionInfo.url)) {
-      throw new Error(`Duplicate use of webhapp url ${versionInfo.url} for tool '${tool.title} ${versionInfo.version}'`);
-    }
-    webhappUrls.add(versionInfo.url);
-    if (!versionInfo.url.toLowerCase().endsWith(".webhapp")) {
-      throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
-    }
-    try {
-      const _url = new URL(versionInfo.url);
-    } catch (e) {
-      throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
-    }
-
-    // Make sure each hash is different
-    if (versionInfo.hashes.happSha256 === versionInfo.hashes.webhappSha256
-        || versionInfo.hashes.happSha256 === versionInfo.hashes.uiSha256
-        || versionInfo.hashes.uiSha256 === versionInfo.hashes.webhappSha256) {
-      throw new Error(`Found identical hashes for tool '${tool.title} ${versionInfo.version}'`);
-    }
-
-  });
-});
-
-// Verify that versionBranch fields are unique for the same tool id
-const idsAndBranches = toolListObject.tools.map(
-  (tool) => `${tool.id}#${tool.versionBranch}`
-);
-if (Array.from(new Set(idsAndBranches)).length !== idsAndBranches.length)
-  throw new Error(
-    "Tool list contains at least two Tools that have the same id and versionBranch. This is not allowed."
-  );
-
-// Verify that happ sha256 are the same for tools in the same versionBranch
-toolListObject.tools.forEach((toolInfo) => {
-  if (
-    Array.from(
-      new Set(
-        toolInfo.versions.map((versionInfo) => versionInfo.hashes.happSha256)
-      )
-    ).length > 1
-  )
+  if (curationListJSON !== curationListActual)
     throw new Error(
-      `happSha256 are not unique for tool ${toolInfo.title} and verisonBranch ${toolInfo.versionBranch}`
+      `Invalid ${label} curation list. List does not match the list defined in ${curationListSource}`
     );
+  if (toolListJSON !== toolListActual)
+    throw new Error(
+      `Invalid ${label} developer collective Tools list. List does not match the list defined in ${toolListSource}`
+    );
+
+  let webhappUrls = new Set();
+
+  // Check each tool
+  toolListObject.tools.forEach((tool) => {
+    // Check Icon URL
+    try {
+      const _iconUrl = new URL(tool.icon);
+    } catch (e) {
+      throw new Error(`Invalid icon URL for tool '${tool.title}' `);
+    }
+    // Check each version
+    tool.versions.forEach((versionInfo) => {
+      // Check version field is valid semver
+      if (!semver.valid(versionInfo.version))
+        throw new Error(
+          `Found invalid semver version ${versionInfo.version} for tool '${tool.title} ${tool.versionBranch}'`
+        );
+
+      // Check releasedAt timestamp
+      if (
+        versionInfo.releasedAt < 1711978174000 ||
+        versionInfo.releasedAt > 2690198974000
+      ) {
+        throw new Error(
+          `Invalid releasedAt timestamp ${versionInfo.releasedAt} for tool '${tool.title} ${versionInfo.version}'.
+           Timestamps must be in milliseconds unix epoch time.`
+        );
+      }
+
+      // Check webhapp URL
+      if (webhappUrls.has(versionInfo.url)) {
+        throw new Error(`Duplicate use of webhapp url ${versionInfo.url} for tool '${tool.title} ${versionInfo.version}'`);
+      }
+      webhappUrls.add(versionInfo.url);
+      if (!versionInfo.url.toLowerCase().endsWith(".webhapp")) {
+        throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
+      }
+      try {
+        const _url = new URL(versionInfo.url);
+      } catch (e) {
+        throw new Error(`Invalid webhapp URL for tool '${tool.title} ${versionInfo.version}'`);
+      }
+
+      // Make sure each hash is different
+      if (versionInfo.hashes.happSha256 === versionInfo.hashes.webhappSha256
+          || versionInfo.hashes.happSha256 === versionInfo.hashes.uiSha256
+          || versionInfo.hashes.uiSha256 === versionInfo.hashes.webhappSha256) {
+        throw new Error(`Found identical hashes for tool '${tool.title} ${versionInfo.version}'`);
+      }
+
+    });
+  });
+
+  // Verify that versionBranch fields are unique for the same tool id
+  const idsAndBranches = toolListObject.tools.map(
+    (tool) => `${tool.id}#${tool.versionBranch}`
+  );
+  if (Array.from(new Set(idsAndBranches)).length !== idsAndBranches.length)
+    throw new Error(
+      "Tool list contains at least two Tools that have the same id and versionBranch. This is not allowed."
+    );
+
+  // Verify that happ sha256 are the same for tools in the same versionBranch
+  if (enforceSameHappPerBranch) {
+    toolListObject.tools.forEach((toolInfo) => {
+      if (
+        Array.from(
+          new Set(
+            toolInfo.versions.map((versionInfo) => versionInfo.hashes.happSha256)
+          )
+        ).length > 1
+      )
+        throw new Error(
+          `happSha256 are not unique for tool ${toolInfo.title} and verisonBranch ${toolInfo.versionBranch}`
+        );
+    });
+  }
+}
+
+validatePair({
+  label: "stable",
+  curationListObject,
+  toolListObject,
+  curationListFile: "./lists/curations-0.16.json",
+  toolListFile: "./lists/tool-list-0.16.json",
+  curationListSource: "./modify/curations-0.16.ts",
+  toolListSource: "./modify/tool-list-0.16.ts",
 });
 
+validatePair({
+  label: "dev",
+  curationListObject: devCurationListObject,
+  toolListObject: devToolListObject,
+  curationListFile: "./lists/curations-dev-0.16.json",
+  toolListFile: "./lists/tool-list-dev-0.16.json",
+  curationListSource: "./modify/curations-dev-0.16.ts",
+  toolListSource: "./modify/tool-list-dev-0.16.ts",
+  enforceSameHappPerBranch: false,
+});

--- a/0.16/write-dev-collective-list.js
+++ b/0.16/write-dev-collective-list.js
@@ -1,0 +1,4 @@
+import fs from 'fs';
+import toolListObject from './modify/tool-list-dev-0.16.ts';
+const toolListJSON = JSON.stringify(toolListObject, undefined, 4);
+fs.writeFileSync('./lists/tool-list-dev-0.16.json', toolListJSON);

--- a/0.16/write-dev-curation-list.js
+++ b/0.16/write-dev-curation-list.js
@@ -1,0 +1,4 @@
+import fs from 'fs';
+import curationListObject from './modify/curations-dev-0.16.ts';
+const curationListJSON = JSON.stringify(curationListObject, undefined, 4);
+fs.writeFileSync('./lists/curations-dev-0.16.json', curationListJSON);

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ https://lightningrodlabs.org/weave-tool-curation/<version>/tool-list-<version>.j
 
 for example `https://lightningrodlabs.org/weave-tool-curation/0.15/curations-0.15.json`.
 
+## Dev curation lists
+
+Each version directory also contains a separate **dev** curation list for publishing
+in-development builds of Tools, deployed alongside the stable lists:
+
+```
+https://lightningrodlabs.org/weave-tool-curation/<version>/curations-dev-<version>.json
+https://lightningrodlabs.org/weave-tool-curation/<version>/tool-list-dev-<version>.json
+```
+
+The dev list is a **separate curation source** — it is not part of the default Lightningrod Labs
+curation. To use it, add the `curations-dev-<version>.json` URL as an additional curation list in
+Moss. Users who don't add it never see the dev Tools. Dev versions are unstable and may break or
+change without notice. See each version directory's `README.md` for how to edit the dev lists.
+
 **When adding a new Moss version directory, the `Move lists to static directory` step in
 [`publish.yaml`](./.github/workflows/publish.yaml) must be updated to copy it** — the step lists
 each version explicitly, so a new directory is not deployed until it is added there.


### PR DESCRIPTION
This branch does two things:

## ziptest → production 0.16 list at `0.6.0-dev.0` (Holochain 0.7.0)
- Updates ziptest in the **production** `0.16/lists/tool-list-0.16.json` + `curations-0.16.json` — the lists Moss 0.16 fetches by default (`DEFAULT_PRODUCTION_TOOL_CURATION_CONFIGS`).
- New `0.6.x` version branch because the Holochain 0.7.0 DNA hash is not backward compatible with `0.5.x`.
- `url` and `hashes` match the released `v0.6.0-dev.0` webhapp (`webhappSha256 271367…`), verified by download.

## Dev curation lists (0.15 + 0.16)
- Adds the dev curation/tool-list infrastructure.
- The 0.16 dev lists are left **empty** — they are for hand-curated in-development tools; ziptest lives in the production list.

Generated from `modify/*.ts` via `npm run write-lists`; `npm run test` validation passes.