### PR TITLE
presence v0.14.9

### DIFF
--- a/0.15/lists/tool-list-0.15.json
+++ b/0.15/lists/tool-list-0.15.json
@@ -1436,6 +1436,17 @@
                     },
                     "changelog": "## Features\n\n-  adds room Asset, suitable for embedding.\n- adds new WebRTC carrier with many improvements over SimplePeer\n- adds Holochain Signals based video/audio carrier for situations without a TURN relay server\n- adds ability to connect to Cloudflare provisioned TURN sever\n- persisted call-settings menu with auto-join audio/video; gear settings menu\n- improved call debug logging\n\n## bug-fixes\n- many connection improvements\n- Area-maximizing grid layout for video panes; tolerate narrow/short landing page.\n- Additional STUN servers; single source of truth for default ICE servers",
                     "releasedAt": 1781569309900
+                },
+                {
+                    "version": "0.14.9",
+                    "url": "https://github.com/lightningrodlabs/presence/releases/download/v0.14.9/presence.webhapp",
+                    "hashes": {
+                        "happSha256": "ae12f5923442acfe498243d5a74333a7f018609d514231f43b8ec0c471743ea8",
+                        "webhappSha256": "0f586782bf310e540826181d9aeb8198409f66c7e485290dae79818b2f09ac95",
+                        "uiSha256": "99c6ed2261149c07f06493eecdd0c35d889d8c2e9f81d5795a21d71f993b5df1"
+                    },
+                    "changelog": "Reliability release. Screen sharing moves to the new WebRTC carrier (requires both ends >= 0.14.9; video with 0.14.8 peers still works; 0.14.7 and older fall back to Holochain-signals audio/video). Fixes one-way audio after signal gaps, screen-share maximize blanking the room, module-state flicker, stuck media capture retry, wrong-peer stats, rejoin cooldowns, chime debouncing, video tile re-attach, and several pane teardown leaks. Clearer connection-status reporting and self-declaring diagnostic exports.",
+                    "releasedAt": 1786044323997
                 }
             ]
         },

--- a/0.15/modify/tool-list-0.15.ts
+++ b/0.15/modify/tool-list-0.15.ts
@@ -1391,6 +1391,17 @@ export default defineDevCollectiveToolList({
           changelog: "## Features\n\n-  adds room Asset, suitable for embedding.\n- adds new WebRTC carrier with many improvements over SimplePeer\n- adds Holochain Signals based video/audio carrier for situations without a TURN relay server\n- adds ability to connect to Cloudflare provisioned TURN sever\n- persisted call-settings menu with auto-join audio/video; gear settings menu\n- improved call debug logging\n\n## bug-fixes\n- many connection improvements\n- Area-maximizing grid layout for video panes; tolerate narrow/short landing page.\n- Additional STUN servers; single source of truth for default ICE servers",
           releasedAt: 1781569309900,
         },
+        {
+          version: "0.14.9",
+          url: "https://github.com/lightningrodlabs/presence/releases/download/v0.14.9/presence.webhapp",
+          hashes: {
+            happSha256: "ae12f5923442acfe498243d5a74333a7f018609d514231f43b8ec0c471743ea8",
+            webhappSha256: "0f586782bf310e540826181d9aeb8198409f66c7e485290dae79818b2f09ac95",
+            uiSha256: "99c6ed2261149c07f06493eecdd0c35d889d8c2e9f81d5795a21d71f993b5df1"
+          },
+          changelog: "Reliability release. Screen sharing moves to the new WebRTC carrier (requires both ends >= 0.14.9; video with 0.14.8 peers still works; 0.14.7 and older fall back to Holochain-signals audio/video). Fixes one-way audio after signal gaps, screen-share maximize blanking the room, module-state flicker, stuck media capture retry, wrong-peer stats, rejoin cooldowns, chime debouncing, video tile re-attach, and several pane teardown leaks. Clearer connection-status reporting and self-declaring diagnostic exports.",
+          releasedAt: 1786044323997,
+        },
       ],
     },
     {


### PR DESCRIPTION
Adds Presence 0.14.9 to the 0.15 tool list (versionBranch 0.14.x).

Release: https://github.com/lightningrodlabs/presence/releases/tag/v0.14.9

- Same happ as 0.14.8 — the packed happ bundle is byte-identical (raw sha256 `203a36f7…` for both, verified by unpacking the released 0.14.8 webhapp), so `happSha256` carries over unchanged and 0.14.9 joins the same networks. UI-only update.
- `webhappSha256`/`uiSha256` verified two ways: raw sha256 of the published asset/embedded dist.zip, and `weave hash-webhapp` (@theweave/cli 0.15.21) — both agree.
- Hash-scheme note for the maintainer: @theweave/cli 0.15.21 computes a different `happSha256` canonicalization (`a06213aa…`) than the one every published 0.15-list entry carries — it returns `a06213aa…` for the already-released 0.14.8 webhapp too, whose entry says `ae12f592…`. Since the existing entries verifiably work in Moss 0.15, this PR keeps the sibling-entry scheme (`ae12f592…`, inherited by byte-identity). If Moss 0.15 actually expects the new-CLI value, say the word and I'll swap it.